### PR TITLE
Use React.Children.map instead of this.props.children.map (WIP)

### DIFF
--- a/dist/photon.js
+++ b/dist/photon.js
@@ -1507,13 +1507,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 				var classes = this.getPtClassSet();
 				var className = (0, _classnames2.default)(this.props.className, classes);
-				var childNavs = void 0;
-
-				if (this.state.children) {
-					childNavs = this.state.children.map(function (child, index) {
-						return _this3.renderNav(child, index);
-					});
-				}
+				var childrens = this.state.children;
+				var childNavs = _react2.default.Children.map(childrens, function (childrens, index) {
+					return _this3.renderNav(childrens, index);
+				});
 
 				return _react2.default.createElement(
 					'nav',

--- a/src/nav-group.jsx
+++ b/src/nav-group.jsx
@@ -49,13 +49,9 @@ export default class NavGroup extends Photon.Component {
 	render() {
 		const classes = this.getPtClassSet();
 		const className = classNames(this.props.className, classes);
-		let childNavs;
-
-		if (this.state.children) {
-			childNavs = this.state.children.map((child, index) => {
-				return this.renderNav(child, index);
-			});
-		}
+		const childrens = this.state.children;
+		const childNavs = React.Children.map(childrens,
+			(childrens, index) => this.renderNav(childrens, index));
 
 		return (
 			<nav className={className} ref={this._node}>


### PR DESCRIPTION
It's necessary to render one `NavGroupItem` inside `NavGroup`.
