### PR TITLE
Fix type of Input component

### DIFF
--- a/dist/photon.js
+++ b/dist/photon.js
@@ -1239,6 +1239,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	Input.propTypes = {
+		type: _react2.default.PropTypes.string,
 		label: _react2.default.PropTypes.string
 	};
 

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -31,5 +31,6 @@ Input.defaultProps = {
 };
 
 Input.propTypes = {
+	type: React.PropTypes.string,
 	label: React.PropTypes.string
 };

--- a/test/form-test.jsx
+++ b/test/form-test.jsx
@@ -22,8 +22,10 @@ describe('input', () => {
 
 	it('Should create a element with type', () => {
 		const instance = ReactTestUtils.renderIntoDocument(<Input type="email"/>);
+		const input = instance.node.querySelector('input');
 
 		expect(instance.node.className).to.be('form-group');
+		expect(input.attributes.getNamedItem('type').value).to.be('email');
 	});
 
 	it('Should update with value', () => {


### PR DESCRIPTION
### current problem

we can't set `type` of Input props.

don't work -> `<Input type="password" />`
