### PR TITLE
Update nav-group.jsx

### DIFF
--- a/src/nav-group.jsx
+++ b/src/nav-group.jsx
@@ -61,7 +61,7 @@ export default class NavGroup extends Photon.Component {
 		}
 		return (
 			<nav className={className} ref={this._node}>
-					{childNavs}
+				{childNavs}
 			</nav>
 		);
 	}


### PR DESCRIPTION
fix 

````
ERROR in ./src/nav-group.jsx

/Users/ngroshin/projects/electron/electrowave/src/nav-group.jsx
  64:6  error  Expected indentation of 4 tab characters but found 5  react/jsx-indent
````